### PR TITLE
Make DeviceInfo.uniqueId optional

### DIFF
--- a/C64U Viewer/Network/C64APIClient.swift
+++ b/C64U Viewer/Network/C64APIClient.swift
@@ -10,7 +10,7 @@ struct DeviceInfo: Codable, Sendable {
     let fpgaVersion: String
     let coreVersion: String
     let hostname: String
-    let uniqueId: String
+    let uniqueId: String?
 
     enum CodingKeys: String, CodingKey {
         case product, hostname


### PR DESCRIPTION
Connecting in Toolbox Mode fails with **"The data couldn't be read because it is missing."**

## Cause

`GET /v1/info` on the C64 Ultimate I tested (firmware **3.14**) returns:

```json
{
  "product" : "C64 Ultimate",
  "firmware_version" : "3.14",
  "fpga_version" : "121",
  "core_version" : "1.47",
  "hostname" : "C64-Ultimate-5327E1",
  "errors" : [  ]
}
```

There is no `unique_id` field. Every property of `DeviceInfo` is a non-optional `let`, so the decoder synthesized by `Codable` requires the key and throws `keyNotFound`. `fetchInfo()` is the gate in `connectToolbox`, so the whole connection fails before anything starts.

## Fix

Mark the property optional — that's enough for the synthesized decoder to skip it. `uniqueId` is read nowhere in the codebase, so no call sites change.

## Caveats

- This is **one device on one firmware version**. I haven't checked the Ultimate REST API docs or a second firmware, so I don't know whether `unique_id` was removed, was never sent by this product variant, or is simply optional. You may want to fix it differently once you can confirm against your own hardware.
- Verified on macOS 15 only (I was porting for that; separate PR). Untested on macOS 26, though this change is platform-independent.