### PR TITLE
Deliver connect completion on the main thread

### DIFF
--- a/C64U Viewer/Network/C64Connection.swift
+++ b/C64U Viewer/Network/C64Connection.swift
@@ -139,6 +139,9 @@ final class C64Connection {
         let client = C64APIClient(host: ip, password: password)
         apiClient = client
 
+        // Callers update AppKit from the completion, so deliver it on the main queue.
+        let finish: (Bool) -> Void = { success in DispatchQueue.main.async { completion?(success) } }
+
         // Verify connection before fully committing
         Task {
             do {
@@ -155,7 +158,7 @@ final class C64Connection {
                 startFPSCounter()
                 recentConnections.addToolbox(ipAddress: ip, password: password, savePassword: savePassword)
                 startStreams()
-                completion?(true)
+                finish(true)
             } catch let error as C64APIError {
                 if case .httpError(403) = error {
                     self.connectionError = "Incorrect password"
@@ -165,13 +168,13 @@ final class C64Connection {
                 Log.error("API error: \(error.localizedDescription)")
                 apiClient = nil
                 connectionMode = nil
-                completion?(false)
+                finish(false)
             } catch {
                 self.connectionError = error.localizedDescription
                 Log.error("API error: \(error.localizedDescription)")
                 apiClient = nil
                 connectionMode = nil
-                completion?(false)
+                finish(false)
             }
         }
     }


### PR DESCRIPTION
`connectToolbox` verifies the device inside an unstructured `Task`, so its completion handler runs on a background thread. The caller (`OpenDeviceWindowController.attemptConnection`) uses that completion to re-enable the Connect button, show the error label, and ask the delegate to open the device window — all AppKit calls, which must run on the main thread.

Off-main AppKit mutation is undefined behavior. On macOS 26 it happens to work. On macOS 15 it doesn't: the Connect button stayed disabled and no device window appeared, so a **successful** connection looked like a hang, with no error shown.

## Fix

Deliver the completion on the main queue, at the source rather than the call site — so `OpenDeviceWindowController` needs no changes and any future caller is safe too. The synchronous `guard !isConnected` early-return is left alone; it already runs on the caller's thread.

## Note

You likely have never seen a symptom of this on macOS 26, so this may look like a fix for nothing. It isn't — it's just latent. The ordering that AppKit happens to tolerate today isn't guaranteed, and it reliably breaks one OS version back.

## Caveats

- Verified on macOS 15 only. Untested on macOS 26, though the change is platform-independent and strictly moves work onto the main thread.