### PR TITLE
Add an Edit menu and stop forwarding menu shortcuts to the C64

### DIFF
--- a/C64U Viewer/AppDelegate.swift
+++ b/C64U Viewer/AppDelegate.swift
@@ -64,6 +64,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, DeviceWindowController
         fileMenuItem.submenu = fileMenu
         mainMenu.addItem(fileMenuItem)
 
+        // Edit menu — items target the first responder, so they reach whatever
+        // text field, text view, or open/save panel is focused.
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        editMenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "Z")
+        editMenu.addItem(.separator())
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Delete", action: #selector(NSText.delete(_:)), keyEquivalent: "")
+        editMenu.addItem(.separator())
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenuItem.submenu = editMenu
+        mainMenu.addItem(editMenuItem)
+
         // Stream menu
         let streamMenuItem = NSMenuItem()
         let streamMenu = NSMenu(title: "Stream")

--- a/C64U Viewer/DeviceWindowController.swift
+++ b/C64U Viewer/DeviceWindowController.swift
@@ -81,6 +81,9 @@ final class DeviceWindowController: NSWindowController, NSToolbarDelegate {
             return false
         }
 
+        // Leave menu shortcuts to the menu bar rather than typing them on the C64.
+        guard !event.modifierFlags.contains(.command) else { return false }
+
         switch Int(event.keyCode) {
         case 36: forwarder.sendKey(0x0D); return true // Return
         case 51: forwarder.sendKey(0x14); return true // Delete


### PR DESCRIPTION
The menu bar is built in code (no `MainMenu.xib`), and had no **Edit** menu.

Cut/Copy/Paste/Undo/Select All aren't built into AppKit's text views — they exist only as key equivalents on the standard Edit menu, whose items dispatch `cut:`/`copy:`/`paste:`/`undo:`/`selectAll:` down the responder chain to the first responder. With no such menu, those shortcuts do nothing anywhere in the app:

- the BASIC scratchpad has **no undo** (⌘Z is dead) and no cut/copy/paste
- you **can't paste** into the IP field, password field, or the Open/Save panels

This adds the standard Edit menu (Undo, Redo, Cut, Copy, Paste, Delete, Select All), with items targeting the first responder. Naming the menu `"Edit"` also restores macOS's automatic Writing Tools / Dictation / Emoji & Symbols items.

## Second, smaller fix (same theme)

`DeviceWindowController.handleKeyDown` forwarded `event.characters` without checking the Command modifier, so a ⌘-key that no menu item claimed was typed into the C64's keyboard buffer. With forwarding enabled, **⌘K typed a `k` on the C64.** Now it ignores events carrying `.command`, so they reach the menu bar instead.

## Testing (macOS 15.7.1, real C64 Ultimate)

Driven against the live app:
- Edit menu present; Paste/Select All enable with a text view focused; Undo retitles to "Undo Typing" and enables after typing; Cut/Copy enable only with a selection.
- ⌘X puts text on the system pasteboard; ⌘V fills the Save panel's filename field (the originally-reported case).
- Confirmed on hardware: **without** the guard, ⌘K types `k` on the C64; **with** it, ⌘K types nothing.

## Scope

Deliberately narrow. The hand-built menu bar is also missing Services, Hide/Hide Others/Show All, and a Help menu — happy to add those, here or separately, if you'd like.

Independent of my other PRs; branches off `main`.